### PR TITLE
Human readable sql output to the console

### DIFF
--- a/easy_profile/reporters.py
+++ b/easy_profile/reporters.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from functools import partial
 import operator
 import sys
-import textwrap
+import sqlparse
 
 import six
 
@@ -116,7 +116,7 @@ class StreamReporter(Reporter):
         for statement, count in most_common:
             if count > 1:
                 # Wrap SQL statement and returning a list of wrapped lines
-                statement = textwrap.fill(statement)
+                statement = str(sqlparse.format(statement, reindent=True, keyword_case='upper'))
                 text = "\nRepeated {0} times:\n{1}\n".format(count, statement)
                 output += self._info_line(text, count)
 

--- a/easy_profile/reporters.py
+++ b/easy_profile/reporters.py
@@ -3,9 +3,9 @@ from collections import OrderedDict
 from functools import partial
 import operator
 import sys
-import sqlparse
 
 import six
+import sqlparse
 
 from .termcolors import colorize
 
@@ -116,7 +116,11 @@ class StreamReporter(Reporter):
         for statement, count in most_common:
             if count > 1:
                 # Wrap SQL statement and returning a list of wrapped lines
-                statement = str(sqlparse.format(statement, reindent=True, keyword_case='upper'))
+                statement = str(
+                    sqlparse.format(
+                        statement, reindent=True, keyword_case="upper"
+                    )
+                )
                 text = "\nRepeated {0} times:\n{1}\n".format(count, statement)
                 output += self._info_line(text, count)
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     keywords=["sqlalchemy", "easy", "profile", "profiler", "profiling"],
-    install_requires=["sqlalchemy>=1.1,<1.4"],
+    install_requires=["sqlalchemy>=1.1,<1.4", "sqlparse>=0.3.0"],
     tests_require=["coverage", "mock"],
     extras_require={"dev": ["tox", "bumpversion"]}
 )

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -1,8 +1,8 @@
 from collections import Counter
-import textwrap
 import unittest
 
 import mock
+import sqlparse
 
 from easy_profile.reporters import shorten, StreamReporter
 
@@ -134,6 +134,8 @@ class TestStreamReporter(unittest.TestCase):
         self.assertRegexpMatches(actual_output, expected_output)
 
         for statement, count in expected_table_stats["duplicates"].items():
-            statement = textwrap.fill(statement)
+            statement = str(
+                sqlparse.format(statement, reindent=True, keyword_case="upper")
+            )
             text = "\nRepeated {0} times:\n{1}\n".format(count, statement)
             self.assertRegexpMatches(actual_output, text)


### PR DESCRIPTION
Adds nice, human readable SQL format to the console output.

This is the way the original console output looks like:

```
Repeated 2 times:
SELECT count(*) AS count_1  FROM (SELECT product.metadata AS
product_metadata, (SELECT sum(forecastsales.quantity) AS sum_1  FROM
forecastsales  WHERE forecastsales.product_id = product.id AND
forecastsales.timestamp >= now() AND forecastsales.forecast_date =
(SELECT max(forecastsales.forecast_date) AS max_1  FROM
forecastsales)) AS anon_2, product.id AS product_id, product.name AS
product_name, product.default_route_id AS product_default_route_id,
product.predicted_demand_per_period AS
product_predicted_demand_per_period, product.minimum_stock_level AS
product_minimum_stock_level, product.type AS product_type  FROM
product) AS anon_1
```

Which is hard to read.

This is how it will look with this change implemented:

```
Repeated 2 times:
SELECT count(*) AS count_1
FROM
  (SELECT product.metadata AS product_metadata,

     (SELECT sum(forecastsales.quantity) AS sum_1
      FROM forecastsales
      WHERE forecastsales.product_id = product.id
        AND forecastsales.timestamp >= now()
        AND forecastsales.forecast_date =
          (SELECT max(forecastsales.forecast_date) AS max_1
           FROM forecastsales)) AS anon_2,
          product.id AS product_id,
          product.name AS product_name,
          product.default_route_id AS product_default_route_id,
          product.predicted_demand_per_period AS product_predicted_demand_per_period,
          product.minimum_stock_level AS product_minimum_stock_level,
          product.type AS product_type
   FROM product) AS anon_1
```

Please let me know if it is a desired change for you.

Take care,

Tomasz