### PR TITLE
Fix profiler session already began error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed an issue where concurrent calls to an API would cause "Profiling session has already begun" exception.
 
 ## [1.0.0] - 2019-03-25
 ### Added

--- a/easy_profile/middleware.py
+++ b/easy_profile/middleware.py
@@ -32,22 +32,23 @@ class EasyProfileMiddleware(object):
             self.reporter = StreamReporter()
 
         self.app = app
-        self.profiler = SessionProfiler(engine)
+        self.engine = engine
         self.exclude_path = exclude_path or []
         self.min_time = min_time
         self.min_query_count = min_query_count
 
     def __call__(self, environ, start_response):
+        profiler = SessionProfiler(self.engine)
         path = environ.get("PATH_INFO", "")
         if not self._ignore_request(path):
             method = environ.get("REQUEST_METHOD")
             if method:
                 path = "{0} {1}".format(method, path)
             try:
-                with self.profiler:
+                with profiler:
                     response = self.app(environ, start_response)
             finally:
-                self._report_stats(path, self.profiler.stats)
+                self._report_stats(path, profiler.stats)
             return response
         return self.app(environ, start_response)
 

--- a/easy_profile/profiler.py
+++ b/easy_profile/profiler.py
@@ -130,7 +130,7 @@ class SessionProfiler(object):
 
         """
         if self.alive:
-            raise AssertionError("Profiling session is already began")
+            raise AssertionError("Profiling session has already began")
 
         self.alive = True
         self.queries = Queue()

--- a/easy_profile/profiler.py
+++ b/easy_profile/profiler.py
@@ -130,7 +130,7 @@ class SessionProfiler(object):
 
         """
         if self.alive:
-            raise AssertionError("Profiling session has already began")
+            raise AssertionError("Profiling session has already begun")
 
         self.alive = True
         self.queries = Queue()

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -3,7 +3,6 @@ import unittest
 import mock
 
 from easy_profile.middleware import EasyProfileMiddleware
-from easy_profile.profiler import SessionProfiler
 from easy_profile.reporters import Reporter, StreamReporter
 
 
@@ -13,7 +12,7 @@ class TestEasyProfileMiddleware(unittest.TestCase):
         mocked_app = mock.Mock()
         mw = EasyProfileMiddleware(mocked_app)
         self.assertEqual(mw.app, mocked_app)
-        self.assertIsInstance(mw.profiler, SessionProfiler)
+        self.assertIs(mw.engine, None)
         self.assertIsInstance(mw.reporter, StreamReporter)
         self.assertEqual(mw.exclude_path, [])
         self.assertEqual(mw.min_time, 0)

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -85,7 +85,7 @@ class TestSessionProfiler(unittest.TestCase):
             profiler.begin()
 
         error = exec_info.exception
-        self.assertEqual(str(error), "Profiling session is already began")
+        self.assertEqual(str(error), "Profiling session has already begun")
 
     def test_commit(self):
         profiler = SessionProfiler()


### PR DESCRIPTION
Fixes an issue with asynchronous call to an API which were causing `SessionProfiler` to report 'session is already began'.

The instantiation of the profiler was moved into the `__call__` method of the `EasyProfileMiddleware`.