### PR TITLE
Add aggregate callstack information gathering.

### DIFF
--- a/easy_profile/reporters.py
+++ b/easy_profile/reporters.py
@@ -86,6 +86,8 @@ class StreamReporter(Reporter):
         summary = "Total queries: {0} in {1:.3}s".format(total, duration)
         output += self._info_line("\n{0}\n".format(summary), total)
 
+        callstacks = stats["callstacks"]
+
         # Display duplicated sql statements.
         #
         # Get top counters were value greater than 1 and write to
@@ -95,11 +97,12 @@ class StreamReporter(Reporter):
         for statement, count in most_common:
             if count < 1:
                 continue
+            callstack = callstacks[statement].most_common(1)
             # Wrap SQL statement and returning a list of wrapped lines
             statement = sqlparse.format(
                 statement, reindent=True, keyword_case="upper"
             )
-            text = "\nRepeated {0} times:\n{1}\n".format(count + 1, statement)
+            text = "\nRepeated {0} times:\n{1}\nMost common callstack {2} times:\n{3}\n".format(count + 1, statement, callstack[0][1], callstack[0][0])
             output += self._info_line(text, count)
 
         self._file.write(output)


### PR DESCRIPTION
I needed more information on where exactly a specific SQL query was coming from, so I added a feature to accumulate tracebacks as it goes and output the most common stacktrace at the end. It turned out this was extra-complicated because I'm using the Jinja templating engine, which has its own functionality to demangle template file line numbers. So there's also a callback provided so you can hook Jinja functionality. If you're curious what that ends up looking like, check out https://github.com/themotte/rDrama/pull/409/commits/fbf05c2fd7ac058ecbfbf42f69305e4f17a14329#diff-1c009483441c45f007d6460d1afece4fcab249c3416e5e029fb8b9a4043e5f91 :)